### PR TITLE
provide feedback from wave to atmosphere

### DIFF
--- a/model/CPL/wave_type.f90
+++ b/model/CPL/wave_type.f90
@@ -21,14 +21,21 @@ type wave_data_type
 
   ! These fields are used to provide information about the waves to the atmosphere/ocean/ice
   real, pointer, dimension(:,:,:) :: &
-       HS => NULL(),         & !< The significant wave height [m]
-       ust_wav => NULL(),    & !< The friction velocity [m/s]
-       ustdir_wav => NULL(), & !< The direction of friction velocity [radians]
-       charn_wav => NULL(),  & !< The Charnock parameter [dimensionless]
-       hs_glo    => NULL(),  &
-       ust_glo   => NULL(),  &
-       ustdir_glo => NULL(), &
-       charn_glo  => NULL()
+       HS         => NULL(),  & !< Significant wave height [m]
+       ust_wav    => NULL(),  & !< Friction velocity [m/s]
+       ustdir_wav => NULL(),  & !< Direction of friction velocity [radians]
+       charn_wav  => NULL(),  & !< Charnock parameter [dimensionless]
+       tauox_wav  => NULL(),  & !< Wave to ocean momentum flux in X-direction
+       tauoy_wav  => NULL()     !< Wave to ocean momentum flux in y-direction
+
+real, pointer, dimension(:,:,:) :: &
+       hs_glo     => NULL(),  &
+       ust_glo    => NULL(),  &
+       ustdir_glo => NULL(),  &
+       charn_glo  => NULL(),  &
+       tauox_glo  => NULL(),  &
+       tauoy_glo  => NULL()
+
   real, pointer, dimension(:,:,:) :: &
        ustkb_mpp => NULL(), &
        vstkb_mpp => NULL(), &
@@ -38,12 +45,6 @@ type wave_data_type
   integer, dimension(:,:), pointer :: & ! (lon, lat,tile)
        glob_loc_X => NULL(), & !
        glob_loc_Y => NULL()
-
-  ! These fields provide information from the atmosphere/ocean/ice to the waves
-  real, pointer, dimension(:,:) :: &
-       U10 => NULL(), &
-       V10 => NULL(), &
-       ICE_CONCENTRATION => NULL()
 
 end type wave_data_type
 
@@ -63,8 +64,12 @@ type ice_wave_boundary_type
    real, dimension(:,:,:), pointer :: & ! (lon, lat,tile)
         wavgrd_Ucurr_mpp => NULL(), & !
         wavgrd_Vcurr_mpp => NULL(), & !
+        wavgrd_Ice_mpp => NULL()
+
+   real, dimension(:,:,:), pointer :: & ! (lon, lat,tile)
         wavgrd_ucurr_glo => NULL(), & !
-        wavgrd_vcurr_glo => NULL()
+        wavgrd_vcurr_glo => NULL(), & !
+        wavgrd_Ice_glo => NULL()
 
    real, dimension(:,:,:,:), pointer :: & ! (lon, lat,tile,Nstk)
         icegrd_ustkb_mpp => NULL(), & !

--- a/model/CPL/wave_type.f90
+++ b/model/CPL/wave_type.f90
@@ -20,9 +20,15 @@ type wave_data_type
   real, pointer, dimension(:) :: stk_wavenumbers => NULL() !< Used for stokes drift
 
   ! These fields are used to provide information about the waves to the atmosphere/ocean/ice
-  real, pointer, dimension(:,:) :: &
-       HS => NULL() !< The significant wave height [m]
-
+  real, pointer, dimension(:,:,:) :: &
+       HS => NULL(),         & !< The significant wave height [m]
+       ust_wav => NULL(),    & !< The friction velocity [m/s]
+       ustdir_wav => NULL(), & !< The direction of friction velocity [radians]
+       charn_wav => NULL(),  & !< The Charnock parameter [dimensionless]
+       hs_glo    => NULL(),  &
+       ust_glo   => NULL(),  &
+       ustdir_glo => NULL(), &
+       charn_glo  => NULL()
   real, pointer, dimension(:,:,:) :: &
        ustkb_mpp => NULL(), &
        vstkb_mpp => NULL(), &
@@ -48,7 +54,6 @@ type atmos_wave_boundary_type
    real, dimension(:,:,:), pointer :: & ! (lon, lat,tile)
         wavgrd_u10_glo => NULL(), & !
         wavgrd_v10_glo => NULL()
-
    integer :: xtype             !REGRID, REDIST or DIRECT
 
 end type atmos_wave_boundary_type

--- a/model/CPL/wavemodel.f90
+++ b/model/CPL/wavemodel.f90
@@ -155,6 +155,7 @@ module wave_model_mod
       integer :: b
 
       integer :: glob_loc_x(NX,NY), glob_loc_y(NX,NY)
+      logical :: is_west, is_east, is_south, is_north
       !----------------------------------------------------------------------
       !Convert the ending time of this call into WW3 time format, which
       ! is integer(2) :: (YYYYMMDD, HHMMSS)
@@ -242,6 +243,7 @@ module wave_model_mod
       call mpp_global_field(Wav%domain,Wav%glob_loc_X,glob_loc_X)
       call mpp_global_field(Wav%domain,Wav%glob_loc_Y,glob_loc_Y)
 
+
       Wav%ustkb_mpp(:,:,:)  = 0.0
       Wav%vstkb_mpp(:,:,:)  = 0.0
       Wav%hs(:,:,:)         = 0.0
@@ -251,7 +253,6 @@ module wave_model_mod
       Wav%tauox_wav(:,:,:)  = 0.0
       Wav%tauoy_wav(:,:,:)  = 0.0
 
-      isea = 1
       do ix=1,NX
          do iy=1,NY
            Pix = glob_loc_X(ix,iy)
@@ -270,6 +271,22 @@ module wave_model_mod
            endif
          enddo
       enddo
+     
+     ! Added by Biao,  WW3 flags the points at four boudaries as excluded, so those cells stay 0.
+     ! Before coupling to MOM6/SHiELD, call fill_boundary to copy the nearest
+     ! interior row/column to these four lines, preventing zeros on domain edges.
+     is_west  = (is == 1)
+     is_east  = (ie == NX)
+     is_south = (js == 1)
+     is_north = (je == NY)
+     call fill_boundary(Wav%ustkb_mpp,  is_west, is_east, is_south, is_north)
+     call fill_boundary(Wav%vstkb_mpp,  is_west, is_east, is_south, is_north) 
+     call fill_boundary(Wav%hs,         is_west, is_east, is_south, is_north)
+     call fill_boundary(Wav%ust_wav,    is_west, is_east, is_south, is_north)
+     call fill_boundary(Wav%ustdir_wav, is_west, is_east, is_south, is_north)
+     call fill_boundary(Wav%charn_wav,  is_west, is_east, is_south, is_north)
+     call fill_boundary(Wav%tauox_wav,  is_west, is_east, is_south, is_north)
+     call fill_boundary(Wav%tauoy_wav,  is_west, is_east, is_south, is_north)
 
       !----------------------------------------------------------------------
       return
@@ -309,6 +326,32 @@ module wave_model_mod
 
       return
     end subroutine wave_model_end
+   
+    !> This subroutine copies the nearest interior row/column onto the outer lines, added by Biao 
+    subroutine fill_boundary(field, is_west, is_east, is_south, is_north)
+      implicit none
+      real, intent(inout) :: field(:,:,:)
+      logical, intent(in) :: is_west, is_east, is_south, is_north
+      !   local variables
+      integer :: nxl,nyl,nzl
 
+      nxl = size(field,1)
+      nyl = size(field,2)
+      nzl = size(field,3)
+      
+      ! Fill the four sides from the adjacent inner column/row 
+      if (is_west) field(1, 1:nyl, 1:nzl)   = field(2, 1:nyl,1:nzl)
+      if (is_east) field(nxl, 1:nyl, 1:nzl) = field(nxl-1, 1:nyl,1:nzl)
+      if (is_south) field(1:nxl, 1, 1:nzl)   = field(1:nxl, 2, 1:nzl)
+      if (is_north) field(1:nxl, nyl, 1:nzl) = field(1:nxl, nyl-1, 1:nzl)
+       
+      ! Corners use the mean of the two adjacent inner points
+      if (is_west  .and. is_south) field(1,   1,   1:nzl) = 0.5*( field(2,   1,   1:nzl) + field(1,   2,   1:nzl) )
+      if (is_east  .and. is_south) field(nxl, 1,   1:nzl) = 0.5*( field(nxl-1,1,   1:nzl) + field(nxl, 2,   1:nzl) )
+      if (is_west  .and. is_north) field(1,   nyl, 1:nzl) = 0.5*( field(2,   nyl, 1:nzl) + field(1,   nyl-1,1:nzl) )
+      if (is_east  .and. is_north) field(nxl, nyl, 1:nzl) = 0.5*( field(nxl-1,nyl,1:nzl) + field(nxl, nyl-1,1:nzl) )
+
+      return
+   end subroutine fill_boundary
 
 end module wave_model_mod

--- a/model/CPL/wavemodel.f90
+++ b/model/CPL/wavemodel.f90
@@ -109,7 +109,14 @@ module wave_model_mod
       Wav%ustkb_glo(:,:,:) = 0.0
       allocate(Wav%vstkb_glo(1:NX,1:NY,Wav%num_stk_bands))
       Wav%vstkb_glo(:,:,:) = 0.0
-
+      allocate(Wav%hs_glo(1:NX,1:NY,1))
+      Wav%hs_glo(:,:,:) = 0.0
+      allocate(Wav%ust_glo(1:NX,1:NY,1))
+      Wav%ust_glo(:,:,:) = 0.0
+      allocate(Wav%ustdir_glo(1:NX,1:NY,1))
+      Wav%ustdir_glo(:,:,:) = 0.0
+      allocate(Wav%charn_glo(1:NX,1:NY,1))
+      Wav%charn_glo(:,:,:) = 0.0
       return
     end subroutine wave_model_init
 
@@ -124,7 +131,8 @@ module wave_model_mod
       use w3gdatmd, only: NX, NY
       use w3idatmd, only: wx0, wxN, wy0, wyN, TW0, TWN, &
                           cx0, cxN, cy0, cyN, TC0, TCN
-      use w3adatmd, only: ussx, ussy, ussp
+      use w3adatmd, only: ussx, ussy, ussp, charn, hs
+      use w3wdatmd, only: ust, ustdir
       use w3gdatmd, only: nseal, mapsf, NK
       use w3odatmd, only: iaproc, naproc
       ! Subroutine arguments
@@ -140,7 +148,6 @@ module wave_model_mod
       integer :: b
 
       integer :: glob_loc_x(NX,NY), glob_loc_y(NX,NY)
-
       !----------------------------------------------------------------------
       !Convert the ending time of this call into WW3 time format, which
       ! is integer(2) :: (YYYYMMDD, HHMMSS)
@@ -183,7 +190,7 @@ module wave_model_mod
 
       Wav%glob_loc_X(:,:) = 0
       Wav%glob_loc_Y(:,:) = 0
-
+      
       call mpp_get_compute_domain( Wav%domain, is, ie, js, je )
       isea = 1
       do ix=is,ie
@@ -198,6 +205,11 @@ module wave_model_mod
               Wav%ustkb_mpp(ix,iy,b) = USSP(isea,b)
               Wav%vstkb_mpp(ix,iy,b) = USSP(isea,NK+b)
             enddo
+            ! send wave variables to coupler and atmospheric model, added by Biao
+            Wav%hs(ix,iy,1) = HS(isea)
+            Wav%ust_wav(ix,iy,1) = UST(isea_g)
+            Wav%ustdir_wav(ix,iy,1) = USTDIR(isea_g)
+            Wav%charn_wav(ix,iy,1) = CHARN(isea)
           endif
           isea = isea+1
         end do
@@ -207,11 +219,22 @@ module wave_model_mod
         call mpp_global_field(Wav%domain,Wav%ustkb_mpp(:,:,b),wav%ustkb_glo(:,:,b))
         call mpp_global_field(Wav%domain,Wav%vstkb_mpp(:,:,b),wav%vstkb_glo(:,:,b))
       enddo
+
+      call mpp_global_field(Wav%domain,Wav%hs,wav%hs_glo)
+      call mpp_global_field(Wav%domain,Wav%ust_wav,wav%ust_glo)
+      call mpp_global_field(Wav%domain,Wav%ustdir_wav,wav%ustdir_glo)
+      call mpp_global_field(Wav%domain,Wav%charn_wav,wav%charn_glo)
+
       call mpp_global_field(Wav%domain,Wav%glob_loc_X,glob_loc_X)
       call mpp_global_field(Wav%domain,Wav%glob_loc_Y,glob_loc_Y)
 
       Wav%ustkb_mpp(:,:,:) = 0.0
       Wav%vstkb_mpp(:,:,:) = 0.0
+
+      Wav%hs(:,:,:)        = 0.0
+      Wav%ust_wav(:,:,:)   = 0.0
+      Wav%ustdir_wav(:,:,:)= 0.0
+      Wav%charn_wav(:,:,:) = 0.0
 
       isea = 1
       do ix=1,NX
@@ -223,12 +246,15 @@ module wave_model_mod
                 Wav%ustkb_mpp(Pix,Piy,b) = wav%ustkb_glo(ix,iy,b)
                 Wav%vstkb_mpp(Pix,Piy,b) = wav%vstkb_glo(ix,iy,b)
               enddo
+                Wav%hs(Pix,Piy,1) = wav%hs_glo(ix,iy,1)
+                Wav%ust_wav(Pix,Piy,1) = wav%ust_glo(ix,iy,1)
+                Wav%ustdir_wav(Pix,Piy,1) = wav%ustdir_glo(ix,iy,1)
+                Wav%charn_wav(Pix,Piy,1) = wav%charn_glo(ix,iy,1)
            endif
          enddo
       enddo
 
       !----------------------------------------------------------------------
-
       return
     end subroutine update_wave_model
 

--- a/model/CPL/wavemodel.f90
+++ b/model/CPL/wavemodel.f90
@@ -93,6 +93,8 @@ module wave_model_mod
       Ice2Waves%wavgrd_ucurr_glo(1:NX,1:NY,1) = 0.0
       allocate(Ice2Waves%wavgrd_vcurr_glo(1:NX,1:NY,1))
       Ice2Waves%wavgrd_vcurr_glo(1:NX,1:NY,1) = 0.0
+      allocate(Ice2Waves%wavgrd_Ice_glo(1:NX,1:NY,1))
+      Ice2Waves%wavgrd_Ice_glo(1:NX,1:NY,1) = 0.0
 
       if (usspf(1).gt.usspf(2)) then
         print*,'usspf(1): ',usspf(1)
@@ -106,17 +108,21 @@ module wave_model_mod
       Wav%stk_wavenumbers(:) = USSP_WN(usspf(1):usspf(2))
 
       allocate(Wav%ustkb_glo(1:NX,1:NY,Wav%num_stk_bands))
-      Wav%ustkb_glo(:,:,:) = 0.0
       allocate(Wav%vstkb_glo(1:NX,1:NY,Wav%num_stk_bands))
-      Wav%vstkb_glo(:,:,:) = 0.0
       allocate(Wav%hs_glo(1:NX,1:NY,1))
-      Wav%hs_glo(:,:,:) = 0.0
       allocate(Wav%ust_glo(1:NX,1:NY,1))
-      Wav%ust_glo(:,:,:) = 0.0
       allocate(Wav%ustdir_glo(1:NX,1:NY,1))
-      Wav%ustdir_glo(:,:,:) = 0.0
       allocate(Wav%charn_glo(1:NX,1:NY,1))
-      Wav%charn_glo(:,:,:) = 0.0
+      allocate(Wav%tauox_glo(1:NX,1:NY,1))
+      allocate(Wav%tauoy_glo(1:NX,1:NY,1))
+      Wav%ustkb_glo(:,:,:)  = 0.0
+      Wav%vstkb_glo(:,:,:)  = 0.0
+      Wav%hs_glo(:,:,:)     = 0.0
+      Wav%ust_glo(:,:,:)    = 0.0
+      Wav%ustdir_glo(:,:,:) = 0.0
+      Wav%charn_glo(:,:,:)  = 0.0
+      Wav%tauox_glo(:,:,:)  = 0.0
+      Wav%tauoy_glo(:,:,:)  = 0.0
       return
     end subroutine wave_model_init
 
@@ -130,9 +136,10 @@ module wave_model_mod
       use wmwavemd, only: wmwave
       use w3gdatmd, only: NX, NY
       use w3idatmd, only: wx0, wxN, wy0, wyN, TW0, TWN, &
-                          cx0, cxN, cy0, cyN, TC0, TCN
-      use w3adatmd, only: ussx, ussy, ussp, charn, hs
-      use w3wdatmd, only: ust, ustdir
+                          cx0, cxN, cy0, cyN, ICEI, TC0, TCN
+      use w3adatmd, only: ussx, ussy, ussp, &
+                          charn, hs, tauox, tauoy
+      use w3wdatmd, only: UST, USTDIR
       use w3gdatmd, only: nseal, mapsf, NK
       use w3odatmd, only: iaproc, naproc
       ! Subroutine arguments
@@ -171,17 +178,20 @@ module wave_model_mod
       TC0(:) = TSTRT(:,1)
       TCN(:) = TEND(:,1)
       call mpp_global_field(Wav%domain,atm2waves%wavgrd_u10_mpp(:,:,:),atm2waves%wavgrd_u10_glo(:,:,:))
-      wx0(:,:) = atm2waves%wavgrd_u10_glo(:,:,1)
+      wx0(:,:) = Atm2Waves%wavgrd_u10_glo(:,:,1)
       wxN(:,:) = wx0(:,:)
       call mpp_global_field(Wav%domain,atm2waves%wavgrd_v10_mpp(:,:,:),atm2waves%wavgrd_v10_glo(:,:,:))
-      wy0(:,:) = atm2waves%wavgrd_v10_glo(:,:,1)
+      wy0(:,:) = Atm2Waves%wavgrd_v10_glo(:,:,1)
       wyN(:,:) = wy0(:,:)
       call mpp_global_field(Wav%domain,ice2waves%wavgrd_ucurr_mpp(:,:,:),ice2waves%wavgrd_ucurr_glo(:,:,:))
-      cx0(:,:) = ice2waves%wavgrd_ucurr_glo(:,:,1)
+      cx0(:,:) = Ice2Waves%wavgrd_ucurr_glo(:,:,1)
       cxN(:,:) = cx0(:,:)
       call mpp_global_field(Wav%domain,ice2waves%wavgrd_vcurr_mpp(:,:,:),ice2waves%wavgrd_vcurr_glo(:,:,:))
-      cy0(:,:) = ice2waves%wavgrd_vcurr_glo(:,:,1)
+      cy0(:,:) = Ice2Waves%wavgrd_vcurr_glo(:,:,1)
       cyN(:,:) = cy0(:,:)
+
+      call mpp_global_field(Wav%domain,ice2waves%wavgrd_Ice_mpp(:,:,:),ice2waves%wavgrd_Ice_glo(:,:,:))
+      ICEI(:,:) = Ice2Waves%wavgrd_Ice_glo(:,:,1)
       ! write(*,*)'Into wave model U10 max: ',maxval(atm2Waves%U_10_global),maxval(wx0)
       ! write(*,*)'Into wave model V10 max: ',maxval(atm2Waves%V_10_global),maxval(wy0)
       ! write(*,*)'Into wave model UO max: ',maxval(ice2Waves%Ucurr_global),maxval(cx0)
@@ -206,10 +216,12 @@ module wave_model_mod
               Wav%vstkb_mpp(ix,iy,b) = USSP(isea,NK+b)
             enddo
             ! send wave variables to coupler and atmospheric model, added by Biao
-            Wav%hs(ix,iy,1) = HS(isea)
-            Wav%ust_wav(ix,iy,1) = UST(isea_g)
-            Wav%ustdir_wav(ix,iy,1) = USTDIR(isea_g)
-            Wav%charn_wav(ix,iy,1) = CHARN(isea)
+            Wav%hs(ix,iy,1)          = HS(isea)
+            Wav%ust_wav(ix,iy,1)     = UST(isea_g)
+            Wav%ustdir_wav(ix,iy,1)  = USTDIR(isea_g)
+            Wav%charn_wav(ix,iy,1)   = CHARN(isea)
+            Wav%tauox_wav(ix,iy,1)   = TAUOX(isea)
+            Wav%tauoy_wav(ix,iy,1)   = TAUOY(isea)
           endif
           isea = isea+1
         end do
@@ -224,17 +236,20 @@ module wave_model_mod
       call mpp_global_field(Wav%domain,Wav%ust_wav,wav%ust_glo)
       call mpp_global_field(Wav%domain,Wav%ustdir_wav,wav%ustdir_glo)
       call mpp_global_field(Wav%domain,Wav%charn_wav,wav%charn_glo)
+      call mpp_global_field(Wav%domain,Wav%tauox_wav,wav%tauox_glo)
+      call mpp_global_field(Wav%domain,Wav%tauoy_wav,wav%tauoy_glo)
 
       call mpp_global_field(Wav%domain,Wav%glob_loc_X,glob_loc_X)
       call mpp_global_field(Wav%domain,Wav%glob_loc_Y,glob_loc_Y)
 
-      Wav%ustkb_mpp(:,:,:) = 0.0
-      Wav%vstkb_mpp(:,:,:) = 0.0
-
-      Wav%hs(:,:,:)        = 0.0
-      Wav%ust_wav(:,:,:)   = 0.0
-      Wav%ustdir_wav(:,:,:)= 0.0
-      Wav%charn_wav(:,:,:) = 0.0
+      Wav%ustkb_mpp(:,:,:)  = 0.0
+      Wav%vstkb_mpp(:,:,:)  = 0.0
+      Wav%hs(:,:,:)         = 0.0
+      Wav%ust_wav(:,:,:)    = 0.0
+      Wav%ustdir_wav(:,:,:) = 0.0
+      Wav%charn_wav(:,:,:)  = 0.0
+      Wav%tauox_wav(:,:,:)  = 0.0
+      Wav%tauoy_wav(:,:,:)  = 0.0
 
       isea = 1
       do ix=1,NX
@@ -250,6 +265,8 @@ module wave_model_mod
                 Wav%ust_wav(Pix,Piy,1) = wav%ust_glo(ix,iy,1)
                 Wav%ustdir_wav(Pix,Piy,1) = wav%ustdir_glo(ix,iy,1)
                 Wav%charn_wav(Pix,Piy,1) = wav%charn_glo(ix,iy,1)
+                Wav%tauox_wav(Pix,Piy,1) = wav%tauox_glo(ix,iy,1)
+                Wav%tauoy_wav(Pix,Piy,1) = wav%tauoy_glo(ix,iy,1)
            endif
          enddo
       enddo
@@ -278,6 +295,15 @@ module wave_model_mod
       deallocate(Atm2Waves%wavgrd_v10_glo)
       deallocate(Ice2Waves%wavgrd_ucurr_glo)
       deallocate(Ice2Waves%wavgrd_vcurr_glo)
+      deallocate(Ice2Waves%wavgrd_Ice_glo)
+      deallocate(Waves%ustkb_glo)
+      deallocate(Waves%vstkb_glo)
+      deallocate(Waves%hs_glo)
+      deallocate(Waves%ust_glo)
+      deallocate(Waves%ustdir_glo)
+      deallocate(Waves%charn_glo)
+      deallocate(Waves%tauox_glo)
+      deallocate(Waves%tauoy_glo)
       CALL MPI_BARRIER ( MPI_COMM, IERR_MPI ) !Do we need this?
       !----------------------------------------------------------------------
 


### PR DESCRIPTION
Commit breakdown

**1st** and **2nd** commit (2ad0541 and 94367a8)
We export UST/USTDIR/CHARN to the exchange grid for SHiELD.  In the other direction, read neutral wind at 10m (SHiELD) and ice fraction (MOM6/SIS2) from the exchange grid into WW3.


**3rd** commit (2656b26)
WW3 marks the points on domain edges as excluded, therefore wave fields at those cells are not populated  and appear as zeros in our outputs. Before coupling to MOM6/SHiELD, we fill them by copying the nearest interior row/column  (with corner handling) to avoid passing zeros at the domain edges.